### PR TITLE
fixes #9722, reverting ImageRepository templating for registry-creds

### DIFF
--- a/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
+++ b/deploy/addons/registry-creds/registry-creds-rc.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
         addonmanager.kubernetes.io/mode: Reconcile
     spec:
       containers:
-      - image: {{default "upmcenterprises" .ImageRepository}}/registry-creds:1.10
+      - image: upmcenterprises/registry-creds:1.10
         name: registry-creds
         imagePullPolicy: Always
         env:


### PR DESCRIPTION
This fixes #9722 by reverting part of yehiyam's add ImageRepository to addons templayes change for the registry-creds addon.

<!-- 🎉 Thank you for contributing to minikube! 🎉 Here are some hints to get your PR merged faster:

1. Your PR title will be included in the release notes, choose it carefully
2. If the PR fixes an issue, add "fixes #<issue number>" to the description.
3. If the PR is a user interface change, please include a "before" and "after" example.
4. If the PR is a large design change, please include an enhancement proposal:
https://github.com/kubernetes/minikube/tree/master/enhancements
-->
